### PR TITLE
added global option to split the binary with various fields to split

### DIFF
--- a/src/babel_index_utils.erl
+++ b/src/babel_index_utils.erl
@@ -108,7 +108,7 @@ build_output([], undefined, Acc) ->
     Acc;
 
 build_output(Keys, Bin, Acc) when is_binary(Bin) ->
-    build_output(Keys, binary:split(Bin, <<$\31>>), Acc);
+    build_output(Keys, binary:split(Bin, <<$\31>>, [global]), Acc);
 
 build_output([X | Xs], [Y | Ys], Acc) ->
     build_output(Xs, Ys, maps:put(X, Y, Acc));


### PR DESCRIPTION
### Scenario

Covered fields configured in the index: `[<<"button">>, <<"name">>, <<"last_name">>]`

Error:
```
* exception error: no function clause matching babel_index_utils:build_output([<<"last_name">>],[],#{[<<"roles">>,<<"mrn:party_role:driver">>,<<"button">>] => <<"afff1234">>, <<"name">> => <<105,118,97,110,32,99,108,25,103,105,111,118,97,110,97,122,122,105,50>>, <<"id">> => <<"mrn:person:fdef79e0-248d-41e9-a607-6b7be7462636">>})
```
Binary decoded that was assigned to the name:`'ivan cl\031giovanazzi2'`